### PR TITLE
Make accelerator duration configurable

### DIFF
--- a/src/main/java/com/xir/NHUtilities/common/entity/EntityTimeAccelerator.java
+++ b/src/main/java/com/xir/NHUtilities/common/entity/EntityTimeAccelerator.java
@@ -14,6 +14,7 @@ import net.minecraft.world.World;
 import org.jetbrains.annotations.NotNull;
 
 import com.xir.NHUtilities.common.api.interfaces.ITileEntityTickAcceleration;
+import com.xir.NHUtilities.config.Config;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
@@ -22,7 +23,7 @@ public class EntityTimeAccelerator extends Entity {
 
     // region Fields
     private int timeRate = enableTimeAcceleratorBoost ? 8 : 4; // must be set in here for texture render init
-    public static final int ACCELERATION_TICK = 600;
+    public static final int ACCELERATION_TICK = Config.getAcceleratorDuration();
     private int remainingTime = ACCELERATION_TICK;
     private boolean isGregTechMachineMode = true;
 

--- a/src/main/java/com/xir/NHUtilities/config/Config.java
+++ b/src/main/java/com/xir/NHUtilities/config/Config.java
@@ -58,6 +58,10 @@ public class Config {
     public static boolean enableNumberMultiplierTexture = false;
     public static boolean enableResetRemainingTime = false;
     public static boolean disableShiftModification = false;
+    public static int acceleratorDuration = 600;
+    public static int getAcceleratorDuration() {
+        return acceleratorDuration;
+    }
     // endregion
 
     // region register mixins category key region
@@ -127,6 +131,14 @@ public class Config {
 
             enableTimeVial = configuration
                 .getBoolean("enableTimeVial", CATEGORY_TIME_VIAL, enableTimeVial, "enable Time Vial");
+
+            acceleratorDuration = configuration.getInt(
+                "acceleratorDuration",
+                CATEGORY_TIME_VIAL,
+                acceleratorDuration,
+                20,
+                72000,
+                "Duration of time accelerator entity in ticks (20 ticks = 1 second)");
 
             enableEternityVial = configuration
                 .getBoolean("enableEternityVial", CATEGORY_TIME_VIAL, enableEternityVial, "enable Eternity Vial");


### PR DESCRIPTION
Replaced the hardcoded ACCELERATION_TICK value in EntityTimeAccelerator with a configurable value from Config. Added acceleratorDuration setting and getter to Config, allowing users to set the duration via configuration.